### PR TITLE
update object to use a relative path root

### DIFF
--- a/XGB_Model.py
+++ b/XGB_Model.py
@@ -63,7 +63,7 @@ class XGB_model():
         print('Calibration time', round(c_time), 's')
         print('Saving Model')
         #adjust this to match changing models
-        pickle.dump(model, open(self.cwd + M_save_filepath, "wb"))   
+        pickle.dump(model, open(self.cwd.joinpath(M_save_filepath), "wb"))   
 
         self.model_=model
         
@@ -78,9 +78,8 @@ class XGB_model():
     
     
     def XGB_Predict(self, test_feat, test_targ):
-        
         #Make predictions with the model
-        model = pickle.load(open(self.cwd+"/Model_History/V2/XGBoost_"+self.Target+".dat", "rb"))
+        model = pickle.load(open(self.cwd.joinpath("/Model_History/V2/XGBoost_"+self.Target+".dat"), "rb"))
         start_time = time.time()  
         #since the previous timestep is being used, we need to predict this value
         predict = []
@@ -439,7 +438,7 @@ class XGB_Tuning():
             self.Final_FeaturesDF = self.Col_Check_feat[self.Final_Features]
 
         #save features list 
-        pickle.dump(self.Final_Features, open(self.cwd + "/Model_History/V2/"+self.targ+"_features.pkl", "wb")) 
+        pickle.dump(self.Final_Features, open(self.cwd.joinpath("/Model_History/V2/"+self.targ+"_features.pkl"), "wb")) 
 
         print('The final features for ', self.targ, 'are: ')
         print(self.Final_FeaturesDF.columns)
@@ -530,10 +529,10 @@ class XGB_Prediction():
         
         print('Processing data into features/targets for ', self.scenario, ' scenario')
         #Input optimial features from XGBoost_WSM_Tuning.
-        LittleDell_Percent_Full = pickle.load(open("Models/V2/LittleDell_Percent_Full_features.pkl", "rb"))
-        Mtn_Dell_Percent_Full = pickle.load(open("Models/V2/Mtn_Dell_Percent_Full_features.pkl", "rb")) 
-        SLCDPU_GW = pickle.load(open("Models/V2/SLCDPU_GW_features.pkl", "rb"))
-        SLCDPU_DC_Water_Use = pickle.load(open("Models/V2/SLCDPU_DC_Water_Use_features.pkl", "rb"))
+        LittleDell_Percent_Full = pickle.load(open(self.cwd.joinpath("BoostModels/LittleDell_Percent_Full_features.pkl"), "rb"))
+        Mtn_Dell_Percent_Full = pickle.load(open(self.cwd.joinpath("BoostModels/Mtn_Dell_Percent_Full_features.pkl"), "rb")) 
+        SLCDPU_GW = pickle.load(open(self.cwd.joinpath("BoostModels/SLCDPU_GW_features.pkl"), "rb"))
+        SLCDPU_DC_Water_Use = pickle.load(open(self.cwd.joinpath("BoostModels/SLCDPU_DC_Water_Use_features.pkl"), "rb"))
 
 
 
@@ -647,10 +646,10 @@ class XGB_Prediction():
         DC_targ = copy.deepcopy(self.targets[self.DC])
 
         #Make predictions with the model, load model from XGBoost_WSM_Tuning
-        MDell_model = pickle.load(open("Models/V1/XGBoost_"+self.MDell+".dat", "rb"))
-        LDell_model = pickle.load(open("Models/V2/XGBoost_"+self.LDell+".dat", "rb"))
-        GW_model = pickle.load(open("Models/V2/XGBoost_"+self.GW+".dat", "rb"))
-        DC_model = pickle.load(open("Models/V2/XGBoost_"+self.DC+".dat", "rb"))
+        MDell_model = pickle.load(open(self.cwd.joinpath("BoostModels/XGBoost_"+self.MDell+".dat"), "rb"))
+        LDell_model = pickle.load(open(self.cwd.joinpath("BoostModels/XGBoost_"+self.LDell+".dat"), "rb"))
+        GW_model = pickle.load(open(self.cwd.joinpath("BoostModels/XGBoost_"+self.GW+".dat"), "rb"))
+        DC_model = pickle.load(open(self.cwd.joinpath("BoostModels/XGBoost_"+self.DC+".dat"), "rb"))
 
 
 

--- a/XGBoost_WSM_Tuning.ipynb
+++ b/XGBoost_WSM_Tuning.ipynb
@@ -8,13 +8,30 @@
    "outputs": [],
    "source": [
     "#my python module\n",
-    "import XGB_Model\n",
+    "!pip install collinearity jenkspy   \n",
     "from pathlib import Path\n",
     "import pandas as pd\n",
     "import os\n",
     "%matplotlib inline\n",
     "import warnings\n",
-    "warnings.filterwarnings(\"ignore\")"
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "import sys\n",
+    "import subprocess\n",
+    "\n",
+    "try:\n",
+    "    import google.colab\n",
+    "\n",
+    "    ENV_IS_CL = True\n",
+    "    cwd = r\"/content/ml_WSM\"\n",
+    "    sys.path.insert(0, cwd)\n",
+    "    subprocess.run([\"git\", \"clone\",  \"https://github.com/whitelightning450/Machine-Learning-Water-Systems-Model\", \"ml_WSM\"])\n",
+    "except:\n",
+    "    cwd = os.getcwd()\n",
+    "    \n",
+    "cwd = Path(cwd)\n",
+    "\n",
+    "import XGB_Model"
    ]
   },
   {
@@ -26,11 +43,10 @@
    "source": [
     "\n",
     "#This is the final dataset to make predictions on\n",
-    "p = Path('Training_Simulations')\n",
+    "p = cwd.joinpath('Training_Simulations')\n",
     "\n",
     "Sims = {i.stem[0:8] : pd.read_excel(i, skiprows = 5) for i in p.glob('**/*.xlsx')}\n",
-    "\n",
-    "cwd = os.getcwd()"
+    "\n"
    ]
   },
   {
@@ -97,7 +113,7 @@
     "DataProcc = XGB_Model.XGB_Tuning(cwd)\n",
     "\n",
     "#Load in data and process accordingly\n",
-    "DataProcc.ProcessData(Sims, 'Obs_Ave', feat, targ, 2021, False, allData = True)\n",
+    "DataProcc.ProcessData(Sims, 'Obs_Ave', feat, targ, 2021, False, allData = True, cwd=cwd)\n",
     "\n",
     "'''\n",
     "This step check to collinearity among features.\n",


### PR DESCRIPTION
Updated the internal execution to use relative paths, which permits direct execution in [useful Open-in-Google-Colab function](https://chrome.google.com/webstore/detail/open-in-colab/iogfkhleblhcpcekbiedikdehleodpjo?hl=en) available in Google Chrome. 

These updates only change the behavior in the `XGBoost_WSM_Tuning.ipynb` notebook. Additional commits or a separate PR should address the changes to ` XGBoost_WSM_v3_uncertainty.ipynb`